### PR TITLE
Fixed issue #54. 

### DIFF
--- a/app/src/main/java/com/example/SocyMusic/PlayerFragment.java
+++ b/app/src/main/java/com/example/SocyMusic/PlayerFragment.java
@@ -174,15 +174,15 @@ public class PlayerFragment extends Fragment {
         fastForwardButton.setOnClickListener(v -> {
             if (MediaPlayerUtil.isPlaying()) {
                 MediaPlayerUtil.seekTo(MediaPlayerUtil.getPosition() + 10000);
-                songStartTimeTextview.setText(MediaPlayerUtil.getPosition());
+                songStartTimeTextview.setText(createTime(MediaPlayerUtil.getPosition()));
             }
         });
 
         // moves 10 seconds backwards in the song
         fastRewindButton.setOnClickListener(v -> {
             if (MediaPlayerUtil.isPlaying()) {
-                MediaPlayerUtil.seekTo(MediaPlayerUtil.getPosition() + 10000);
-                songStartTimeTextview.setText(MediaPlayerUtil.getPosition());
+                MediaPlayerUtil.seekTo(MediaPlayerUtil.getPosition() - 10000);
+                songStartTimeTextview.setText(createTime(MediaPlayerUtil.getPosition()));
             }
         });
 

--- a/app/src/main/java/com/example/SocyMusic/SongsData.java
+++ b/app/src/main/java/com/example/SocyMusic/SongsData.java
@@ -16,7 +16,6 @@ public class SongsData {
     private SongsData() {
         reloadSongs();
         playingQueue = new ArrayList<>();
-        repeat = false;
     }
 
     public Song getSongPlaying() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -71,13 +71,14 @@
                 android:marqueeRepeatLimit="marquee_forever"
                 android:singleLine="true"
                 android:text="Song name goes here"
+                tools:ignore="HardcodedText"
                 android:textColor="@color/black" />
 
             <Button
                 android:id="@+id/bsh_play_button"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
-                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
                 android:background="@drawable/ic_pause" />
 
 


### PR DESCRIPTION
App was crashing because we call setText() on the media player position not the time returned by createTime() so it thought media player position was a resource. Don't know why we removed the call to createTime()