### PR TITLE
Fixed issue #77

### DIFF
--- a/app/src/main/java/com/example/SocyMusic/MediaPlayerUtil.java
+++ b/app/src/main/java/com/example/SocyMusic/MediaPlayerUtil.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.media.MediaPlayer;
 import android.net.Uri;
 
-import java.util.Random;
-
 public class MediaPlayerUtil {
     private static MediaPlayer mediaPlayer;
 
@@ -48,6 +46,7 @@ public class MediaPlayerUtil {
     public static void playNext(Context context) {
         // Fixed instance
         SongsData songsData = SongsData.getInstance();
+<<<<<<< Updated upstream
         // Shuffles the queue
         if (songsData.isShuffle() && !songsData.isRepeat()) {
             int randomIndex = getRandomIndex();
@@ -58,6 +57,10 @@ public class MediaPlayerUtil {
             SongsData.getInstance().setPlaying(randomIndex);
         // Repeats the song
         } else if (songsData.isRepeat()) {
+=======
+        // Repeats the song
+        if (songsData.isRepeat()) {
+>>>>>>> Stashed changes
             SongsData.getInstance().setPlaying(songsData.currentSongIndex());
         // Plays the first song in queue
         } else if (songsData.lastInQueue() && !songsData.isRepeat()) {
@@ -79,6 +82,7 @@ public class MediaPlayerUtil {
     public static void playPrev(Context context) {
         // Fixed instance
         SongsData songsData = SongsData.getInstance();
+<<<<<<< Updated upstream
         // Shuffles the queue
         if (songsData.isShuffle() && !songsData.isRepeat()) {
             int randomIndex = getRandomIndex();
@@ -88,6 +92,9 @@ public class MediaPlayerUtil {
             }
             SongsData.getInstance().setPlaying(randomIndex);
         } else if (songsData.isRepeat()) {
+=======
+        if (songsData.isRepeat()) {
+>>>>>>> Stashed changes
             SongsData.getInstance().setPlaying(songsData.currentSongIndex());
         // Plays the last song in queue
         } else if (songsData.firstInQueue() && !songsData.isRepeat()) {
@@ -180,6 +187,7 @@ public class MediaPlayerUtil {
             return 0;
         return mediaPlayer.getAudioSessionId();
     }
+<<<<<<< Updated upstream
 
     /**
      * Generates a random index for the shuffle mode
@@ -189,4 +197,6 @@ public class MediaPlayerUtil {
         Random r = new Random();
         return r.nextInt(SongsData.getInstance().songsCount());
     }
+=======
+>>>>>>> Stashed changes
 }

--- a/app/src/main/java/com/example/SocyMusic/MediaPlayerUtil.java
+++ b/app/src/main/java/com/example/SocyMusic/MediaPlayerUtil.java
@@ -46,21 +46,8 @@ public class MediaPlayerUtil {
     public static void playNext(Context context) {
         // Fixed instance
         SongsData songsData = SongsData.getInstance();
-<<<<<<< Updated upstream
-        // Shuffles the queue
-        if (songsData.isShuffle() && !songsData.isRepeat()) {
-            int randomIndex = getRandomIndex();
-            // Avoids playing the same song twice
-            while (randomIndex == songsData.currentSongIndex() && SongsData.getInstance().songsCount() != 0) {
-                randomIndex = getRandomIndex();
-            }
-            SongsData.getInstance().setPlaying(randomIndex);
-        // Repeats the song
-        } else if (songsData.isRepeat()) {
-=======
         // Repeats the song
         if (songsData.isRepeat()) {
->>>>>>> Stashed changes
             SongsData.getInstance().setPlaying(songsData.currentSongIndex());
         // Plays the first song in queue
         } else if (songsData.lastInQueue() && !songsData.isRepeat()) {
@@ -82,19 +69,7 @@ public class MediaPlayerUtil {
     public static void playPrev(Context context) {
         // Fixed instance
         SongsData songsData = SongsData.getInstance();
-<<<<<<< Updated upstream
-        // Shuffles the queue
-        if (songsData.isShuffle() && !songsData.isRepeat()) {
-            int randomIndex = getRandomIndex();
-            // Avoids playing the same song twice
-            while (randomIndex == songsData.currentSongIndex() && SongsData.getInstance().songsCount() != 0) {
-                randomIndex = getRandomIndex();
-            }
-            SongsData.getInstance().setPlaying(randomIndex);
-        } else if (songsData.isRepeat()) {
-=======
         if (songsData.isRepeat()) {
->>>>>>> Stashed changes
             SongsData.getInstance().setPlaying(songsData.currentSongIndex());
         // Plays the last song in queue
         } else if (songsData.firstInQueue() && !songsData.isRepeat()) {

--- a/app/src/main/java/com/example/SocyMusic/SongsData.java
+++ b/app/src/main/java/com/example/SocyMusic/SongsData.java
@@ -3,6 +3,13 @@ package com.example.SocyMusic;
 import android.os.Environment;
 import java.io.File;
 import java.util.ArrayList;
+<<<<<<< Updated upstream
+=======
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+>>>>>>> Stashed changes
 
 public class SongsData {
     public static SongsData data;
@@ -202,7 +209,21 @@ public class SongsData {
      * Changes the shuffle mode of the player
      * @param shuffle True if shuffle mode should be activated
      */
+<<<<<<< Updated upstream
     public void setShuffle(boolean shuffle) {this.shuffle = shuffle;}
+=======
+    public void setShuffle(boolean shuffle) {
+        this.shuffle = shuffle;
+        if (shuffle) {
+            // Create random queue
+            setRandomQueue();
+        } else {
+            // rests queue to original
+            playAllFrom(0);
+        }
+
+    }
+>>>>>>> Stashed changes
 
     /**
      * Checks if the index is currently at the last position in the array
@@ -226,5 +247,34 @@ public class SongsData {
      */
     public int currentSongIndex() {
         return playingQueueIndex;
+    }
+
+    /**
+     * Overried the current playingQueue and creates a random queue
+     */
+    public void setRandomQueue() {
+        // Temporary Arraylist to store all the songs
+        ArrayList<Song> temporary;
+        temporary = new ArrayList<>();
+        final Random r = new Random();
+        // Avoids getting double random numbers
+        // Example: The number 5 only gets called once
+        final Set<Integer> s = new HashSet<>();
+        // Adds the currently playing song, we dont want to shuffle this one too
+        temporary.add(getSongPlaying());
+        // Creates a random queue
+        for (int i = 1; i < playingQueue.size(); i++) {
+            while(true) {
+                int num = r.nextInt(playingQueue.size());
+                // leaves out currently playing song
+                if (!s.contains(num) && num != currentSongIndex()) {
+                    s.add(num);
+                    temporary.add(getSongAt(num));
+                    break;
+                }
+            }
+        }
+        // replaces queue
+        playingQueue = temporary;
     }
 }

--- a/app/src/main/java/com/example/SocyMusic/SongsData.java
+++ b/app/src/main/java/com/example/SocyMusic/SongsData.java
@@ -3,13 +3,12 @@ package com.example.SocyMusic;
 import android.os.Environment;
 import java.io.File;
 import java.util.ArrayList;
-<<<<<<< Updated upstream
-=======
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
->>>>>>> Stashed changes
+
 
 public class SongsData {
     public static SongsData data;
@@ -209,9 +208,6 @@ public class SongsData {
      * Changes the shuffle mode of the player
      * @param shuffle True if shuffle mode should be activated
      */
-<<<<<<< Updated upstream
-    public void setShuffle(boolean shuffle) {this.shuffle = shuffle;}
-=======
     public void setShuffle(boolean shuffle) {
         this.shuffle = shuffle;
         if (shuffle) {
@@ -223,7 +219,6 @@ public class SongsData {
         }
 
     }
->>>>>>> Stashed changes
 
     /**
      * Checks if the index is currently at the last position in the array


### PR DESCRIPTION
Created a new method in SongsData which overrides the current queue with a random generated one.  This only gets called when the shuffle checkbox is checked. If it gets unchecked, the queue turns back to the original again.
This highly improves the comfort because you don't get a random generated song every time you go forward or backward in the queue, but only generate it once and can see what comes next.