### PR TITLE
Made the directory browser easier to use

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'com.github.hendrawd:StorageUtil:1.0.0'
+    implementation 'com.github.sephiroth74:Tri-State-Checkbox:1.0.0'
     debugImplementation 'androidx.fragment:fragment-testing:1.3.5'
 
 

--- a/app/src/main/java/com/musicplayer/SocyMusic/DirBrowserActivity.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/DirBrowserActivity.java
@@ -41,20 +41,6 @@ public class DirBrowserActivity extends AppCompatActivity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.dir_browser, menu);
-        return super.onCreateOptionsMenu(menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        if (item.getItemId() == R.id.dir_browser_menu_save) {
-            dirBrowserFragment.save();
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-    @Override
     public void onBackPressed() {
         dirBrowserFragment.onBackPressed();
     }

--- a/app/src/main/java/com/musicplayer/SocyMusic/MainActivity.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/MainActivity.java
@@ -7,8 +7,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -32,6 +34,7 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
@@ -113,8 +116,12 @@ public class MainActivity extends AppCompatActivity implements PlayerFragment.Pl
                     actionBar.setTitle(R.string.all_app_name);
                     songTitleTextView.setText(songsData.getSongPlaying().getTitle());
                     playButton.setBackgroundResource(MediaPlayerUtil.isPlaying() ? R.drawable.ic_pause : R.drawable.ic_play);
+
+                    ((ViewGroup.MarginLayoutParams) listView.getLayoutParams()).bottomMargin = dpToPixel(50);
+
                     hideQueue();
-                }
+                } else if (newState == BottomSheetBehavior.STATE_HIDDEN)
+                    ((ViewGroup.MarginLayoutParams) listView.getLayoutParams()).bottomMargin = dpToPixel(0);
             }
 
             @Override
@@ -546,4 +553,10 @@ public class MainActivity extends AppCompatActivity implements PlayerFragment.Pl
         });
     }
 
+    private int dpToPixel(int dp) {
+        return (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                dp,
+                getResources().getDisplayMetrics());
+    }
 }

--- a/app/src/main/java/com/musicplayer/SocyMusic/custom_views/EmptyRecyclerView.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/custom_views/EmptyRecyclerView.java
@@ -1,0 +1,72 @@
+package com.musicplayer.SocyMusic.custom_views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+
+/**
+ * Custom RecyclerView that has an empty to show when empty and hide when not automatically,
+ * just like ListView's setEmptyView() method.
+ * Code taken from: https://stackoverflow.com/a/27801394/14200676
+ */
+public class EmptyRecyclerView extends RecyclerView {
+    private View emptyView;
+    final private AdapterDataObserver observer = new AdapterDataObserver() {
+        @Override
+        public void onChanged() {
+            checkIfEmpty();
+        }
+
+        @Override
+        public void onItemRangeInserted(int positionStart, int itemCount) {
+            checkIfEmpty();
+        }
+
+        @Override
+        public void onItemRangeRemoved(int positionStart, int itemCount) {
+            checkIfEmpty();
+        }
+    };
+
+    public EmptyRecyclerView(Context context) {
+        super(context);
+    }
+
+    public EmptyRecyclerView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public EmptyRecyclerView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    void checkIfEmpty() {
+        if (emptyView != null && getAdapter() != null) {
+            final boolean emptyViewVisible = getAdapter().getItemCount() == 0;
+            emptyView.setVisibility(emptyViewVisible ? VISIBLE : GONE);
+            setVisibility(emptyViewVisible ? GONE : VISIBLE);
+        }
+    }
+
+    @Override
+    public void setAdapter(Adapter adapter) {
+        final Adapter oldAdapter = getAdapter();
+        if (oldAdapter != null) {
+            oldAdapter.unregisterAdapterDataObserver(observer);
+        }
+        super.setAdapter(adapter);
+        if (adapter != null) {
+            adapter.registerAdapterDataObserver(observer);
+        }
+
+        checkIfEmpty();
+    }
+
+    public void setEmptyView(View emptyView) {
+        this.emptyView = emptyView;
+        checkIfEmpty();
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,9 +14,7 @@
         android:layout_height="match_parent"
         android:divider="@android:color/transparent"
         android:dividerHeight="10.0sp"
-        android:padding="8dp"
-        android:layout_marginBottom="50dp">
-
+        android:padding="8dp">
     </ListView>
 
     <TextView

--- a/app/src/main/res/layout/fragment_dir_browser.xml
+++ b/app/src/main/res/layout/fragment_dir_browser.xml
@@ -15,7 +15,7 @@
         android:textSize="18sp"
         tools:ignore="HardcodedText" />
 
-    <androidx.recyclerview.widget.RecyclerView
+    <com.musicplayer.SocyMusic.custom_views.EmptyRecyclerView
         android:id="@+id/recyclerview_dir_browser"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/list_item_dir_browser.xml
+++ b/app/src/main/res/layout/list_item_dir_browser.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -10,25 +11,36 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="70dp"
         android:background="@drawable/main_list_background"
-        android:padding="8dp">
+        android:padding="4dp">
 
+        <LinearLayout
+            android:id="@+id/layout_dir_item_checkbox_holder"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_centerVertical="true"
+            android:paddingHorizontal="10dp">
 
-        <CheckBox
-            android:id="@+id/checkbox_dir_item_selected"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_centerVertical="true" />
+            <it.sephiroth.android.library.checkbox3state.CheckBox3
+                android:id="@+id/checkbox_dir_item_selected"
+                style="@style/Sephiroth.Widget.Checkbox3"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:enabled="true"
+                android:text="@null"
+                app:sephiroth_checkbox3_checkableCycle="@array/sephiroth_checkbox3_cycleCheckedUncheckedOnly"
+                app:sephiroth_checkbox3_indeterminate="false" />
+        </LinearLayout>
 
         <ImageView
             android:id="@+id/imageview_dir_item"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:layout_centerVertical="true"
-            android:layout_marginStart="5dp"
             android:layout_marginTop="5dp"
-            android:layout_toEndOf="@id/checkbox_dir_item_selected"
+            android:layout_toEndOf="@id/layout_dir_item_checkbox_holder"
             android:src="@drawable/ic_folder" />
 
         <TextView
@@ -50,5 +62,4 @@
             tools:ignore="HardcodedText" />
 
     </RelativeLayout>
-
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/menu/dir_browser.xml
+++ b/app/src/main/res/menu/dir_browser.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item
-        android:id="@+id/dir_browser_menu_save"
-        android:title="@string/dir_browser_menu_item_save"
-        app:showAsAction="ifRoom|withText" />
-
-</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="dir_browser_internal_storage">Internal Storage</string>
     <string name="dir_browser_sd_card">SD card (%s)</string>
     <string name="dir_browser_folder_list_empty">Folder is empty</string>
-    <string name="dir_browser_file_not_readable">Cannot read file</string>.
+    <string name="dir_browser_folder_unreadable">Cannot access folder</string>.
 
     <string name="dir_browser_menu_item_save">Save</string>
 


### PR DESCRIPTION
Made the directory browser easier to use with the following changes:

- A custom [tri-state checkbox](https://github.com/sephiroth74/Tri-State-Checkbox) shows when a folder contains saved folders with its intermediate state.
- No save button. Changes are saved instantly with every check box click
- Hidden folders are no longer shown and inaccessible folders are greyed out
- Made the checkbox respond to clicks from a large margin around it. This should reduce miss-clicks
- Long pressing a folder checks its checkbox for convenience
- A message shows when the folder is empty. This was there previously but had to be removed when I switched from a ListView to a RecyclerView because RecyclerViews don't have a convenient setEmptyView() method. So I used a custom RecyclerView implementation I found online [here](https://stackoverflow.com/a/27801394/14200676). I created a package for custom views in case we use any more of them.

I also made the bottom margin in MainActivity show and hide programmatically to get rid of that ugly black bar at the bottom when no song is clicked. [This was on my mind for a long time lol](https://github.com/Benji377/SocyMusic/pull/50#issuecomment-858105883)