### PR TITLE
Logging

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -117,9 +117,12 @@
         <entry key="..\:/Users/tech.assistant2/Desktop/Benji/git/SocyMusic/app/src/main/res/layout/preferences.xml" value="0.15104166666666666" />
         <entry key="..\:/Users/tech.assistant2/Desktop/Benji/git/SocyMusic/app/src/main/res/layout/preferences_category.xml" value="0.15104166666666666" />
         <entry key="..\:/Users/tech.assistant2/Desktop/Benji/git/SocyMusic/app/src/main/res/xml/preferences.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/activity_settings.xml" value="0.19427083333333334" />
+        <entry key="app/src/main/res/xml/preferences.xml" value="0.19427083333333334" />
       </map>
     </option>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
     <option name="myDefaultNotNull" value="androidx.annotation.NonNull" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- <uses-permission android:name="android.permission.READ_LOGS" /> -->
 
     <permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.musicplayer.musicplayer">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/com/musicplayer/SocyMusic/SocyMusicApp.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/SocyMusicApp.java
@@ -15,6 +15,8 @@ import androidx.core.content.ContextCompat;
 
 import com.musicplayer.musicplayer.R;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 
 import timber.log.Timber;
@@ -44,6 +46,35 @@ public class SocyMusicApp extends Application {
         Timber.plant(new Timber.DebugTree());
         createNotificationChannels();
         defaultPathsSet.add(Environment.getExternalStorageDirectory().getAbsolutePath());
+
+        // Saves logcat output to a textfile!
+        if (isExternalStorageWritable()) {
+            File appDirectory = new File( Environment.getExternalStorageDirectory() + "/SocyMusic" );
+            File logDirectory = new File( appDirectory + "/logs" );
+            File logFile = new File(logDirectory, "logcat_" + System.currentTimeMillis() + ".txt" );
+
+            // create app folder
+            if (!appDirectory.exists() ) {
+                appDirectory.mkdir();
+            }
+
+            // create log folder
+            if (!logDirectory.exists() ) {
+                logDirectory.mkdir();
+            }
+
+            // clear the previous logcat and then write the new one to the file
+            try {
+                Process process = Runtime.getRuntime().exec("logcat -c");
+                process = Runtime.getRuntime().exec("logcat -f " + logFile);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else if ( isExternalStorageReadable() ) {
+            Timber.e("Storage only readable");
+        } else {
+            Timber.e("Storage not accessible");
+        }
     }
 
     /**
@@ -70,6 +101,19 @@ public class SocyMusicApp extends Application {
         for (String permission : PERMISSIONS_NEEDED)
             allGranted = allGranted && ContextCompat.checkSelfPermission(context, permission) == PERMISSION_GRANTED;
         return allGranted;
+    }
+
+    /* Checks if external storage is available for read and write */
+    public boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        return Environment.MEDIA_MOUNTED.equals(state);
+    }
+
+    /* Checks if external storage is available to at least read */
+    public boolean isExternalStorageReadable() {
+        String state = Environment.getExternalStorageState();
+        return Environment.MEDIA_MOUNTED.equals(state) ||
+                Environment.MEDIA_MOUNTED_READ_ONLY.equals(state);
     }
 
 }

--- a/app/src/main/java/com/musicplayer/SocyMusic/ui/main/MainActivity.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/ui/main/MainActivity.java
@@ -142,7 +142,7 @@ public class MainActivity extends PlayerFragmentHost implements AllSongsFragment
      * For musicplayer storage permission to find all the songs and record permission for the visualizer
      */
     public void runtimePermission() {
-        Dexter.withContext(this).withPermissions(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.RECORD_AUDIO)
+        Dexter.withContext(this).withPermissions(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.RECORD_AUDIO, Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 .withListener(new MultiplePermissionsListener() {
                     @Override
                     public void onPermissionsChecked(MultiplePermissionsReport multiplePermissionsReport) {

--- a/app/src/main/java/com/musicplayer/SocyMusic/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/ui/settings/SettingsFragment.java
@@ -21,6 +21,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     private Preference themePreference;
     private Preference libPathPreference;
     private Preference versions;
+    private Preference logging;
 
     private SongsData songsData;
     private Host hostCallBack;
@@ -37,6 +38,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         libPathPreference = findPreference(SocyMusicApp.PREFS_KEY_LIBRARY_PATHS);
         themePreference = findPreference(SocyMusicApp.PREFS_KEY_THEME);
         versions = findPreference(SocyMusicApp.PREFS_KEY_VERSION);
+        logging = findPreference(SocyMusicApp.PREFS_KEY_LOGGING);
         ActivityResultLauncher<Intent> launcher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
             hostCallBack.onLibraryDirsChanged();
         });

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,6 +22,18 @@
             android:entries="@array/themeOptions"
             android:entryValues="@array/themeValues"/>
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="Debugging"
+        app:key="logging_category"
+        android:icon="@drawable/ic_queue">
+        <SwitchPreference
+            app:key="logging"
+            app:summary="Enable saving log files for debugging"
+            app:title="Logs"
+            app:defaultValue="true"/>
+    </PreferenceCategory>
+
     <PreferenceCategory
         android:title="@string/main_menu_item_about"
         app:key="about"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Purpose
After new users started using the app new issues were raised that we weren't aware of. With this, we quickly realized that we had no way of checking what went wrong on other people's app since there was no debugging mode and the app doesn't send any data to any server whatsoever.

## Approach
The solution we came up with was to read the logcat at runtime and write everything to a text file. This would allow us to ask people to just send us their latest log files easily. The name of the file also equals a timestamp in milliseconds.

## Additional info
There is now also an option to enable and disable logging. To make the change take effect the app needs to be restarted.
We might also create a way to export the files more easily as right now the files get automatically created in the following path:
`Android/data/com.musicplayer.SocyMusic/logs`

