### PR TITLE
Adding support for additional song formats

### DIFF
--- a/app/src/main/java/com/musicplayer/SocyMusic/data/SongsData.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/data/SongsData.java
@@ -42,7 +42,10 @@ public class SongsData {
     private boolean shuffle;
     private boolean doneLoading;
 
-    public static final String[] SUPPORTED_FORMATS = {".mp3", ".wav"};
+    // Contains a list of all supported extensions.
+    // Especially concerned about .ts as it is not seekable and might break the app
+    public static final String[] SUPPORTED_FORMATS = {".mp3", ".wav", ".ogg", ".3gp", ".mp4", ".m4a",
+            ".aac", ".ts", ".amr", ".flac", ".mid", ".xmf", ".mxmf", ".rtttl", ".rtx", ".ota", ".imy", ".mkv"};
     public static final UUID FAVORITES_PLAYLIST_ID = UUID.fromString("3a47e9a7-7cb6-4b47-8b98-7ee7d4b865f0");
 
     /**
@@ -323,6 +326,7 @@ public class SongsData {
                     // Convert file to song and add it to the array
                     // Arrays.stream(items).anyMatch(inputString::contains)
                     // singlefile.getName().endsWith(".mp3") || singlefile.getName().endsWith(".wav")
+                    // Checks if the file extension is one of the supported file formats
                     if (Arrays.stream(SUPPORTED_FORMATS).parallel().anyMatch(getFileExtension(singlefile)::contains)) {
                         songsFound.add(new Song(UUID.randomUUID(), singlefile));
                     }

--- a/app/src/main/java/com/musicplayer/SocyMusic/data/SongsData.java
+++ b/app/src/main/java/com/musicplayer/SocyMusic/data/SongsData.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -41,6 +42,7 @@ public class SongsData {
     private boolean shuffle;
     private boolean doneLoading;
 
+    public static final String[] SUPPORTED_FORMATS = {".mp3", ".wav"};
     public static final UUID FAVORITES_PLAYLIST_ID = UUID.fromString("3a47e9a7-7cb6-4b47-8b98-7ee7d4b865f0");
 
     /**
@@ -319,14 +321,31 @@ public class SongsData {
                     songsFound.addAll(loadSongs(singlefile));
                 } else {
                     // Convert file to song and add it to the array
-                    if (singlefile.getName().endsWith(".mp3") || singlefile.getName().endsWith(".wav")) {
+                    // Arrays.stream(items).anyMatch(inputString::contains)
+                    // singlefile.getName().endsWith(".mp3") || singlefile.getName().endsWith(".wav")
+                    if (Arrays.stream(SUPPORTED_FORMATS).parallel().anyMatch(getFileExtension(singlefile)::contains)) {
                         songsFound.add(new Song(UUID.randomUUID(), singlefile));
                     }
                 }
             }
         }
-
         return songsFound;
+    }
+
+    /**
+     * This method is needed in the loadSong method to get only the
+     * File extension and therefore identify the type of songs
+     * accurately
+     * @param file File to check
+     * @return Nothing if it has no extension, else the whole extension (with dot)
+     */
+    private String getFileExtension(File file) {
+        String name = file.getName();
+        int lastIndexOf = name.lastIndexOf(".");
+        if (lastIndexOf == -1) {
+            return ""; // empty extension
+        }
+        return name.substring(lastIndexOf);
     }
 
     public int getPlayingQueueCount() {


### PR DESCRIPTION
## Purpose
One of the requested features was more compatibility with different file types. This would allow much wider support for more systems and people.

## Approach
According to [this website](https://developer.android.com/guide/topics/media/media-formats) and if I understood it correctly, there is a big variety of song formats the media player supports by default and we can just add them without any too complicated implementations.